### PR TITLE
feat: add session api with role-based access

### DIFF
--- a/justmeet/package-lock.json
+++ b/justmeet/package-lock.json
@@ -23,6 +23,7 @@
         "socket.io": "^4.8.1",
         "socket.io-client": "^4.8.1",
         "tailwind-merge": "^3.3.1",
+        "zod": "^3.25.76",
         "zustand": "^5.0.8"
       },
       "devDependencies": {
@@ -7849,6 +7850,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/justmeet/package.json
+++ b/justmeet/package.json
@@ -24,6 +24,7 @@
     "socket.io": "^4.8.1",
     "socket.io-client": "^4.8.1",
     "tailwind-merge": "^3.3.1",
+    "zod": "^3.25.76",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/justmeet/prisma/schema.prisma
+++ b/justmeet/prisma/schema.prisma
@@ -7,11 +7,17 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum Role {
+  USER
+  ADMIN
+}
+
 model User {
   id        String      @id @default(cuid())
   email     String      @unique
   password  String
   name      String?
+  role      Role        @default(USER)
   wallet    Wallet?
   sessions  Session[]
   orders    Order[]

--- a/justmeet/src/app/api/session/route.ts
+++ b/justmeet/src/app/api/session/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { prisma } from "@/lib/prisma"
+import { redis } from "@/lib/redis"
+import { withRole } from "@/lib/auth"
+
+const createSessionSchema = z.object({
+  userId: z.string().cuid(),
+  expiresAt: z.coerce.date(),
+})
+
+const sessionResponseSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  expiresAt: z.date(),
+  createdAt: z.date(),
+})
+
+export const POST = withRole(async (req: NextRequest) => {
+  const idempotencyKey = req.headers.get("idempotency-key")
+  if (!idempotencyKey) {
+    return NextResponse.json({ error: "Missing idempotency key" }, { status: 400 })
+  }
+  const cacheKey = `session:create:${idempotencyKey}`
+  const cached = await redis.get(cacheKey)
+  if (cached) {
+    const data = sessionResponseSchema.parse(JSON.parse(cached))
+    return NextResponse.json(data)
+  }
+  const body = await req.json()
+  const parsed = createSessionSchema.parse(body)
+  const session = await prisma.session.create({
+    data: { userId: parsed.userId, expiresAt: parsed.expiresAt },
+  })
+  const data = sessionResponseSchema.parse(session)
+  await redis.set(cacheKey, JSON.stringify(data), "EX", 60)
+  return NextResponse.json(data)
+}, ["admin"])
+
+const getSessionSchema = z.object({ id: z.string().cuid() })
+
+export const GET = withRole(async (req: NextRequest) => {
+  const { searchParams } = new URL(req.url)
+  const params = getSessionSchema.parse({ id: searchParams.get("id") })
+  const session = await prisma.session.findUnique({ where: { id: params.id } })
+  if (!session) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 })
+  }
+  const data = sessionResponseSchema.parse(session)
+  return NextResponse.json(data)
+}, ["admin", "user"])

--- a/justmeet/src/lib/auth.ts
+++ b/justmeet/src/lib/auth.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getServerSession } from "next-auth"
+import { authOptions } from "@/app/api/auth/[...nextauth]/route"
+import type { Role } from "@prisma/client"
+
+export function withRole(
+  handler: (req: NextRequest) => Promise<NextResponse> | NextResponse,
+  roles: string[]
+) {
+  return async (req: NextRequest) => {
+    const session = await getServerSession(authOptions)
+    const role = (session?.user as { role?: Role })?.role
+    if (!session || !role || !roles.includes(role)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    }
+    return handler(req)
+  }
+}


### PR DESCRIPTION
## Summary
- add Role enum and role field to Prisma schema
- propagate user role in NextAuth callbacks
- introduce role-based middleware and session API with Zod validation and Redis idempotency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae290ee5f8832d9083f91f93619aac