### PR TITLE
feat(admin): add protected admin pages

### DIFF
--- a/justmeet/src/app/admin/coin-packs/page.tsx
+++ b/justmeet/src/app/admin/coin-packs/page.tsx
@@ -1,0 +1,29 @@
+import { prisma } from "@/lib/prisma"
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table"
+
+export default async function CoinPacksPage() {
+  const coinPacks = await prisma.coinPack.findMany()
+  return (
+    <div>
+      <h1 className="mb-4 text-2xl font-bold">Coin Packs</h1>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Coins</TableHead>
+            <TableHead>Price</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {coinPacks.map((pack) => (
+            <TableRow key={pack.id}>
+              <TableCell>{pack.name}</TableCell>
+              <TableCell>{pack.coins}</TableCell>
+              <TableCell>${'{'}pack.price / 100{'}'}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/justmeet/src/app/admin/layout.tsx
+++ b/justmeet/src/app/admin/layout.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from "react"
+import { getServerSession } from "next-auth"
+import { redirect } from "next/navigation"
+import { authOptions } from "@/app/api/auth/[...nextauth]/route"
+
+export default async function AdminLayout({ children }: { children: ReactNode }) {
+  const session = await getServerSession(authOptions)
+  if (!session || session.user?.role !== "ADMIN") {
+    redirect("/")
+  }
+  return <div className="container mx-auto p-4">{children}</div>
+}

--- a/justmeet/src/app/admin/listings/page.tsx
+++ b/justmeet/src/app/admin/listings/page.tsx
@@ -1,0 +1,31 @@
+import { prisma } from "@/lib/prisma"
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table"
+
+export default async function ListingsPage() {
+  const listings = await prisma.listing.findMany({
+    include: { user: true, coinPack: true },
+  })
+  return (
+    <div>
+      <h1 className="mb-4 text-2xl font-bold">Listings</h1>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>User</TableHead>
+            <TableHead>Coin Pack</TableHead>
+            <TableHead>Price</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {listings.map((listing) => (
+            <TableRow key={listing.id}>
+              <TableCell>{listing.user.email}</TableCell>
+              <TableCell>{listing.coinPack?.name ?? ""}</TableCell>
+              <TableCell>${'{'}listing.price / 100{'}'}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/justmeet/src/app/admin/payments/page.tsx
+++ b/justmeet/src/app/admin/payments/page.tsx
@@ -1,0 +1,27 @@
+import { prisma } from "@/lib/prisma"
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table"
+
+export default async function PaymentsPage() {
+  const payments = await prisma.payment.findMany({ include: { user: true } })
+  return (
+    <div>
+      <h1 className="mb-4 text-2xl font-bold">Payments</h1>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>User</TableHead>
+            <TableHead>Amount</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {payments.map((payment) => (
+            <TableRow key={payment.id}>
+              <TableCell>{payment.user?.email ?? ""}</TableCell>
+              <TableCell>${'{'}payment.amount / 100{'}'}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/justmeet/src/app/admin/users/page.tsx
+++ b/justmeet/src/app/admin/users/page.tsx
@@ -1,0 +1,27 @@
+import { prisma } from "@/lib/prisma"
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table"
+
+export default async function UsersPage() {
+  const users = await prisma.user.findMany()
+  return (
+    <div>
+      <h1 className="mb-4 text-2xl font-bold">Users</h1>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Email</TableHead>
+            <TableHead>Role</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {users.map((user) => (
+            <TableRow key={user.id}>
+              <TableCell>{user.email}</TableCell>
+              <TableCell>{user.role}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/justmeet/src/components/ui/table.tsx
+++ b/justmeet/src/components/ui/table.tsx
@@ -1,0 +1,93 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="relative w-full overflow-x-auto">
+      <table
+        ref={ref}
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+)
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <thead ref={ref} className={cn(className)} {...props} />
+  )
+)
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tbody ref={ref} className={cn(className)} {...props} />
+  )
+)
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tfoot ref={ref} className={cn("bg-muted font-medium", className)} {...props} />
+  )
+)
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <th
+      ref={ref}
+      className={cn(
+        "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <td
+      ref={ref}
+      className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+      {...props}
+    />
+  )
+)
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.HTMLAttributes<HTMLTableCaptionElement>>(
+  ({ className, ...props }, ref) => (
+    <caption ref={ref} className={cn("mt-4 text-sm text-muted-foreground", className)} {...props} />
+  )
+)
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}


### PR DESCRIPTION
## Summary
- add table UI component
- add NextAuth-protected admin section with coin packs, listings, users, and payments tables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae2fb75fa0832da5e939d1f5275722