### PR TITLE
feat: add listing forms and sessions page

### DIFF
--- a/justmeet/src/app/listings/[id]/edit/page.tsx
+++ b/justmeet/src/app/listings/[id]/edit/page.tsx
@@ -1,0 +1,74 @@
+import { getServerSession } from "next-auth"
+import { redirect } from "next/navigation"
+import { prisma } from "@/lib/prisma"
+import { authOptions } from "@/app/api/auth/[...nextauth]/route"
+
+interface Props {
+  params: { id: string }
+}
+
+export default async function EditListingPage({ params }: Props) {
+  const [listing, coinPacks] = await Promise.all([
+    prisma.listing.findUnique({ where: { id: params.id } }),
+    prisma.coinPack.findMany(),
+  ])
+
+  if (!listing) {
+    return <div>Listing not found</div>
+  }
+
+  async function updateListing(formData: FormData) {
+    'use server'
+    const session = await getServerSession(authOptions)
+    if (!session?.user?.id) {
+      redirect("/api/auth/signin")
+    }
+    const coinPackId = formData.get("coinPackId")?.toString() || null
+    const price = Number(formData.get("price"))
+    await prisma.listing.update({
+      where: { id: params.id },
+      data: {
+        coinPackId,
+        price,
+      },
+    })
+    redirect("/listings")
+  }
+
+  return (
+    <form action={updateListing} className="space-y-4">
+      <div>
+        <label className="mb-1 block">Coin Pack</label>
+        <select
+          name="coinPackId"
+          defaultValue={listing.coinPackId ?? ""}
+          className="w-full rounded border p-2"
+        >
+          <option value="">None</option>
+          {coinPacks.map((pack) => (
+            <option key={pack.id} value={pack.id}>
+              {pack.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="mb-1 block">Price (cents)</label>
+        <input
+          type="number"
+          name="price"
+          defaultValue={listing.price}
+          className="w-full rounded border p-2"
+          required
+        />
+      </div>
+      <button
+        type="submit"
+        className="rounded bg-blue-500 px-4 py-2 text-white"
+      >
+        Save
+      </button>
+    </form>
+  )
+}
+

--- a/justmeet/src/app/listings/new/page.tsx
+++ b/justmeet/src/app/listings/new/page.tsx
@@ -1,0 +1,58 @@
+import { getServerSession } from "next-auth"
+import { redirect } from "next/navigation"
+import { prisma } from "@/lib/prisma"
+import { authOptions } from "@/app/api/auth/[...nextauth]/route"
+
+export default async function NewListingPage() {
+  const coinPacks = await prisma.coinPack.findMany()
+
+  async function createListing(formData: FormData) {
+    'use server'
+    const session = await getServerSession(authOptions)
+    if (!session?.user?.id) {
+      redirect("/api/auth/signin")
+    }
+    const coinPackId = formData.get("coinPackId")?.toString() || null
+    const price = Number(formData.get("price"))
+    await prisma.listing.create({
+      data: {
+        userId: session.user.id as string,
+        coinPackId,
+        price,
+      },
+    })
+    redirect("/listings")
+  }
+
+  return (
+    <form action={createListing} className="space-y-4">
+      <div>
+        <label className="mb-1 block">Coin Pack</label>
+        <select name="coinPackId" className="w-full rounded border p-2">
+          <option value="">None</option>
+          {coinPacks.map((pack) => (
+            <option key={pack.id} value={pack.id}>
+              {pack.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="mb-1 block">Price (cents)</label>
+        <input
+          type="number"
+          name="price"
+          className="w-full rounded border p-2"
+          required
+        />
+      </div>
+      <button
+        type="submit"
+        className="rounded bg-blue-500 px-4 py-2 text-white"
+      >
+        Create
+      </button>
+    </form>
+  )
+}
+

--- a/justmeet/src/app/listings/page.tsx
+++ b/justmeet/src/app/listings/page.tsx
@@ -8,11 +8,25 @@ export default async function ListingsPage() {
   return (
     <div>
       <h1 className="mb-4 text-2xl font-bold">Listings</h1>
+      <div className="mb-4">
+        <Link
+          href="/listings/new"
+          className="rounded bg-blue-500 px-4 py-2 text-white"
+        >
+          New Listing
+        </Link>
+      </div>
       <ul>
         {listings.map((listing) => (
           <li key={listing.id} className="mb-2">
             <Link href={`/listings/${listing.id}`}>
               {listing.coinPack?.name ?? "Listing"} - ${'{'}listing.price / 100{'}'}
+            </Link>
+            <Link
+              href={`/listings/${listing.id}/edit`}
+              className="ml-2 text-sm text-blue-500"
+            >
+              Edit
             </Link>
           </li>
         ))}

--- a/justmeet/src/app/sessions/page.tsx
+++ b/justmeet/src/app/sessions/page.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link"
+import { getServerSession } from "next-auth"
+import { prisma } from "@/lib/prisma"
+import { authOptions } from "@/app/api/auth/[...nextauth]/route"
+
+export default async function SessionsPage() {
+  const session = await getServerSession(authOptions)
+
+  if (!session?.user?.id) {
+    return <div>Please sign in to view your sessions.</div>
+  }
+
+  const sessions = await prisma.session.findMany({
+    where: {
+      userId: session.user.id as string,
+      expiresAt: { gt: new Date() },
+    },
+    orderBy: { createdAt: "desc" },
+  })
+
+  return (
+    <div>
+      <h1 className="mb-4 text-2xl font-bold">Live Sessions</h1>
+      <ul>
+        {sessions.map((s) => (
+          <li key={s.id} className="mb-2">
+            <Link href={`/session/${s.id}`}>{s.id}</Link> -
+            <span className="ml-1 text-sm text-gray-600">
+              expires {s.expiresAt.toLocaleString()}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add server-action forms to create and edit listings
- list live sessions for signed-in members
- link to create or edit listings from listings page

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aea731521c832d9c081d7fa9c5073c